### PR TITLE
支持扩容中直接加载路由和节点信息（避免重新启动节点）

### DIFF
--- a/src/backend/pgxc/slot/slot.c
+++ b/src/backend/pgxc/slot/slot.c
@@ -644,7 +644,7 @@ SlotUploadFromCurrentDB(void)
 		if(INVALID_SLOT_VALUE== slotnode[slotForm->slotid])
 		{
 			find_invalid_nodeindex = true;
-			sprintf(msg, "load adb_slot failed.node name %s in adb_slot table does not exist in pgxc_node", NameStr(slotForm->nodename));
+			sprintf(msg, "%s load adb_slot failed.node name %s in adb_slot table does not exist in pgxc_node", PGXCNodeName, NameStr(slotForm->nodename));
 			break;
 		}
 		slotstatus[slotForm->slotid] = slotForm->status;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4514,18 +4514,15 @@ PostgresMain(int argc, char *argv[],
 
 		InitMultinodeExecutor(false);
 
-		if (!IsConnFromCoord())
+		pool_handle = GetPoolManagerHandle();
+		if (pool_handle == NULL)
 		{
-			pool_handle = GetPoolManagerHandle();
-			if (pool_handle == NULL)
-			{
-				ereport(ERROR,
-					(errcode(ERRCODE_IO_ERROR),
-					 errmsg("Can not connect to pool manager")));
-			}
-			/* Pooler initialization has to be made before ressource is released */
-			PoolManagerConnect(pool_handle, dbname, username, session_options());
+			ereport(ERROR,
+				(errcode(ERRCODE_IO_ERROR),
+				 errmsg("Can not connect to pool manager")));
 		}
+		/* Pooler initialization has to be made before ressource is released */
+		PoolManagerConnect(pool_handle, dbname, username, session_options());
 
 		ResourceOwnerRelease(CurrentResourceOwner, RESOURCE_RELEASE_BEFORE_LOCKS, true, true);
 		ResourceOwnerRelease(CurrentResourceOwner, RESOURCE_RELEASE_LOCKS, true, true);


### PR DESCRIPTION
对所有节点调用pgxc_pool_reload，即可更新集群节点信息。
如当前事务操作的节点发生路由切换，会提示事务已中断。
修改内容
1.adbmgr
（1）EXPAND ACTIVATE命令中增加flush slot操作
（2）CLUSTER PGXCNODE INIT命令最后增加对所有节点调用pgxc_pool_reload
2.pg server
（1）datanode节点信息的刷新采用与coordinator相同的方式，修改HandlePoolerReload和pgxc_pool_reload函数
（2）coordinator被间接访问时，直接连接poolmgr，避免测试脚本中，session节点信息不能被更新的错误